### PR TITLE
Crashbug Fix

### DIFF
--- a/ghost/gameprotocol.cpp
+++ b/ghost/gameprotocol.cpp
@@ -166,7 +166,7 @@ CIncomingChatPlayer *CGameProtocol :: RECEIVE_W3GS_CHAT_TO_HOST( BYTEARRAY data 
 	//		4 bytes				-> ExtraFlags
 	//		null term string	-> Message
 
-	if( ValidateLength( data ) )
+	if( ValidateLength( data ) && data.size() >= 5)
 	{
 		unsigned int i = 5;
 		unsigned char Total = data[4];


### PR DESCRIPTION
The executable will throw an out_of_range exception here when the data size is exactly 4, because data[4] needs a size of 5 or more, which is not checked for. ValidateLength only validates the first 4 bytes. A small but important oversight.